### PR TITLE
feat: daemon management + fix reachability and wildcard 404 routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Proxy a chat completion request through the provider fallback chain. Supports bo
 - Requires a JSON body with a `model` field
 - Max body size: 1 MB
 - On 2xx-4xx from a provider: returns the response immediately (client errors are not retried)
+- Exception: 404 from a wildcard (`["*"]`) provider falls through to the next provider (the wildcard provider doesn't have the requested model)
 - On 5xx or network error: falls back to the next provider
 - If all providers fail: returns 502
 
@@ -173,7 +174,11 @@ Request logs are written as JSONL to `~/.config/synapse/logs/requests.log`.
 After installing, the `synapse` command is available:
 
 ```
-synapse start          Start the server (foreground)
+synapse start          Start the server (background daemon)
+synapse stop           Stop the daemon
+synapse status         Show daemon status
+synapse restart        Restart the daemon
+synapse serve          Start the server (foreground)
 synapse health         Check health of running instance
 synapse config         Print resolved configuration
 synapse logs [n]       Show last n request log entries (default: 10)
@@ -183,17 +188,23 @@ synapse version        Show version
 All commands support `--json` for machine-readable output.
 
 ```sh
-# check if the server is running and providers are healthy
+# start synapse in the background
+synapse start
+
+# check daemon status
+synapse status
+
+# check provider health
 synapse health
 
-# view resolved config (with env vars interpolated, API keys masked)
+# view resolved config (API keys masked)
 synapse config
 
 # tail the last 25 request log entries
 synapse logs 25
 
-# JSON output for scripting
-synapse health --json
+# stop the daemon
+synapse stop
 ```
 
 ## Development

--- a/src/config.ts
+++ b/src/config.ts
@@ -196,15 +196,23 @@ function validateConfig(raw: unknown): SynapseConfig {
 
 // --- Load ---
 
-export function loadConfig(configPath?: string): SynapseConfig {
+export function loadConfig(options?: {
+  configPath?: string;
+  quiet?: boolean;
+}): SynapseConfig {
   const envPort = process.env.SYNAPSE_PORT;
   const filePath =
-    configPath ?? process.env.SYNAPSE_CONFIG_PATH ?? DEFAULT_CONFIG_PATH;
+    options?.configPath ??
+    process.env.SYNAPSE_CONFIG_PATH ??
+    DEFAULT_CONFIG_PATH;
+  const quiet = options?.quiet ?? false;
 
   if (!existsSync(filePath)) {
-    console.log(
-      `synapse: no config at ${filePath}, using defaults (ollama @ localhost:11434)`,
-    );
+    if (!quiet) {
+      console.log(
+        `synapse: no config at ${filePath}, using defaults (ollama @ localhost:11434)`,
+      );
+    }
     const config = { ...DEFAULT_CONFIG };
     if (envPort) {
       config.port = parsePort(envPort, "SYNAPSE_PORT");
@@ -228,8 +236,10 @@ export function loadConfig(configPath?: string): SynapseConfig {
     config.port = parsePort(envPort, "SYNAPSE_PORT");
   }
 
-  console.log(
-    `synapse: loaded config from ${filePath} (${config.providers.length} provider(s))`,
-  );
+  if (!quiet) {
+    console.log(
+      `synapse: loaded config from ${filePath} (${config.providers.length} provider(s))`,
+    );
+  }
   return config;
 }

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1,0 +1,191 @@
+/**
+ * Daemon management for Synapse.
+ *
+ * Handles starting/stopping the server as a background process.
+ * PID and log files stored in ~/.config/synapse/
+ */
+
+import { existsSync, readFileSync, unlinkSync, writeFileSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
+import { loadConfig } from "./config";
+
+const DATA_DIR = join(homedir(), ".config", "synapse");
+const PID_FILE = join(DATA_DIR, "synapse.pid");
+const LOG_FILE = join(DATA_DIR, "synapse.log");
+
+export interface DaemonStatus {
+  running: boolean;
+  pid?: number;
+  port?: number;
+  uptime?: number;
+}
+
+/**
+ * Check if a process with the given PID is running.
+ */
+function isProcessRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Read PID from file, returns undefined if not found or invalid.
+ */
+function readPid(): number | undefined {
+  if (!existsSync(PID_FILE)) {
+    return undefined;
+  }
+  try {
+    const content = readFileSync(PID_FILE, "utf-8").trim();
+    const pid = Number.parseInt(content, 10);
+    return Number.isNaN(pid) ? undefined : pid;
+  } catch {
+    return undefined;
+  }
+}
+
+function writePid(pid: number): void {
+  writeFileSync(PID_FILE, pid.toString(), "utf-8");
+}
+
+function removePidFile(): void {
+  if (existsSync(PID_FILE)) {
+    unlinkSync(PID_FILE);
+  }
+}
+
+/**
+ * Get daemon status.
+ */
+export async function getDaemonStatus(): Promise<DaemonStatus> {
+  const pid = readPid();
+
+  if (!pid) {
+    return { running: false };
+  }
+
+  if (!isProcessRunning(pid)) {
+    removePidFile();
+    return { running: false };
+  }
+
+  // Try to get health info from the running server
+  let port: number;
+  try {
+    const config = loadConfig({ quiet: true });
+    port = config.port;
+  } catch {
+    port = 7750;
+  }
+
+  try {
+    const response = await fetch(`http://localhost:${port}/health`);
+    if (response.ok) {
+      return { running: true, pid, port };
+    }
+  } catch {
+    // Server might be starting up
+  }
+
+  return { running: true, pid, port };
+}
+
+/**
+ * Start the daemon.
+ * Returns true if started successfully, false if already running.
+ */
+export async function startDaemon(): Promise<boolean> {
+  const status = await getDaemonStatus();
+
+  if (status.running) {
+    console.log(`synapse daemon already running (PID: ${status.pid})`);
+    return false;
+  }
+
+  let port: number;
+  try {
+    const config = loadConfig({ quiet: true });
+    port = config.port;
+  } catch {
+    port = 7750;
+  }
+
+  const cliPath = join(import.meta.dir, "cli.ts");
+
+  const proc = Bun.spawn(["bun", "run", cliPath, "serve"], {
+    stdout: Bun.file(LOG_FILE),
+    stderr: Bun.file(LOG_FILE),
+    stdin: "ignore",
+  });
+
+  writePid(proc.pid);
+
+  // Wait for the server to start
+  await new Promise((resolve) => setTimeout(resolve, 500));
+
+  const newStatus = await getDaemonStatus();
+  if (newStatus.running) {
+    console.log(`synapse daemon started (PID: ${proc.pid}, port: ${port})`);
+    return true;
+  }
+
+  console.error("Failed to start synapse daemon. Check logs:", LOG_FILE);
+  removePidFile();
+  return false;
+}
+
+/**
+ * Stop the daemon.
+ * Returns true if stopped successfully, false if not running.
+ */
+export async function stopDaemon(): Promise<boolean> {
+  const status = await getDaemonStatus();
+
+  if (!status.running || !status.pid) {
+    console.log("synapse daemon is not running");
+    return false;
+  }
+
+  try {
+    process.kill(status.pid, "SIGTERM");
+
+    const maxWait = 5000;
+    const interval = 100;
+    let waited = 0;
+
+    while (waited < maxWait) {
+      await new Promise((resolve) => setTimeout(resolve, interval));
+      waited += interval;
+
+      if (!isProcessRunning(status.pid)) {
+        break;
+      }
+    }
+
+    if (isProcessRunning(status.pid)) {
+      process.kill(status.pid, "SIGKILL");
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+
+    removePidFile();
+    console.log(`synapse daemon stopped (was PID: ${status.pid})`);
+    return true;
+  } catch (error) {
+    console.error("Error stopping daemon:", error);
+    removePidFile();
+    return false;
+  }
+}
+
+/**
+ * Restart the daemon.
+ */
+export async function restartDaemon(): Promise<boolean> {
+  await stopDaemon();
+  return startDaemon();
+}

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -176,7 +176,7 @@ export async function listModels(
 }
 
 /**
- * Check basic reachability of a provider (HEAD /models).
+ * Check basic reachability of a provider (GET /models).
  */
 export async function checkReachable(
   provider: ProviderConfig,
@@ -191,7 +191,6 @@ export async function checkReachable(
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 5_000);
     const response = await fetch(url, {
-      method: "HEAD",
       headers,
       signal: controller.signal,
     });

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -57,7 +57,10 @@ describe("loadConfig", () => {
   });
 
   test("returns defaults when config file does not exist", () => {
-    const config = loadConfig(join(tmpDir, "nonexistent.json"));
+    const config = loadConfig({
+      configPath: join(tmpDir, "nonexistent.json"),
+      quiet: true,
+    });
     expect(config.port).toBe(7750);
     expect(config.providers).toHaveLength(1);
     expect(config.providers[0].name).toBe("ollama");
@@ -79,7 +82,7 @@ describe("loadConfig", () => {
       }),
     );
 
-    const config = loadConfig(configPath);
+    const config = loadConfig({ configPath, quiet: true });
     expect(config.port).toBe(9000);
     expect(config.providers[0].name).toBe("test-provider");
     expect(config.providers[0].maxFailures).toBe(3); // default applied
@@ -102,7 +105,7 @@ describe("loadConfig", () => {
       }),
     );
 
-    const config = loadConfig(configPath);
+    const config = loadConfig({ configPath, quiet: true });
     expect(config.providers[0].apiKey).toBe("sk-test-123");
     delete process.env.TEST_API_KEY;
   });
@@ -124,7 +127,7 @@ describe("loadConfig", () => {
       }),
     );
 
-    const config = loadConfig(configPath);
+    const config = loadConfig({ configPath, quiet: true });
     expect(config.port).toBe(8888);
     delete process.env.SYNAPSE_PORT;
   });
@@ -133,7 +136,7 @@ describe("loadConfig", () => {
     const configPath = join(tmpDir, "config.json");
     writeFileSync(configPath, JSON.stringify({ providers: [] }));
 
-    expect(() => loadConfig(configPath)).toThrow("non-empty");
+    expect(() => loadConfig({ configPath, quiet: true })).toThrow("non-empty");
   });
 
   test("validates provider fields", () => {
@@ -145,6 +148,8 @@ describe("loadConfig", () => {
       }),
     );
 
-    expect(() => loadConfig(configPath)).toThrow("non-empty string");
+    expect(() => loadConfig({ configPath, quiet: true })).toThrow(
+      "non-empty string",
+    );
   });
 });


### PR DESCRIPTION
## Summary

Three changes in one PR:

### 1. Daemon management (matches engram pattern)

New commands for background process management:

| Command | Description |
|---------|-------------|
| `synapse start` | Start as background daemon (was foreground, now daemon) |
| `synapse stop` | Stop the daemon |
| `synapse status` | Show daemon status (PID, port) |
| `synapse restart` | Restart the daemon |
| `synapse serve` | Start in foreground (renamed from `start`) |

PID file at `~/.config/synapse/synapse.pid`, daemon logs at `~/.config/synapse/synapse.log`.

### 2. Fix: reachability check (HEAD -> GET)

`checkReachable` was using `HEAD /models` which returns 405 on Ollama and Groq, causing `reachable: false` in health checks despite the providers being fully functional. Changed to `GET /models` which is universally supported.

### 3. Fix: 404 from wildcard providers now falls through

Previously, a 404 from any provider was treated as a client error and returned immediately. This broke routing when a wildcard (`["*"]`) provider didn't have the requested model -- the 404 was returned instead of trying the next provider.

Now: 404 from a wildcard provider triggers fallthrough to the next provider. 404 from a non-wildcard provider still returns immediately (existing behavior). The wildcard provider is not penalized (no health failure recorded) since "I don't have this model" isn't a health issue.

**Before:** `qwen/qwen3-32b` -> local-gpu (wildcard, 404) -> returned 404 to client
**After:** `qwen/qwen3-32b` -> local-gpu (wildcard, 404, skip) -> groq (has model, 200) -> success

### Other

- `loadConfig()` accepts `{ quiet: true }` to suppress log output (used by daemon and health commands)
- Two new router tests for wildcard 404 fallthrough behavior (35 total, all pass)

## Files Changed

| File | Change |
|------|--------|
| `src/daemon.ts` | New -- daemon management |
| `src/cli.ts` | Restructured commands (start/stop/status/restart/serve) |
| `src/config.ts` | Added `quiet` option to `loadConfig()` |
| `src/provider.ts` | HEAD -> GET in `checkReachable` |
| `src/router.ts` | 404 wildcard fallthrough logic |
| `test/router.test.ts` | Two new tests for wildcard 404 behavior |
| `test/config.test.ts` | Updated for new `loadConfig()` signature |
| `README.md` | Updated CLI section |