### PR TITLE
feat: add uptime to status command and health endpoint

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -107,8 +107,19 @@ async function cmdStatus(json: boolean): Promise<void> {
     process.exit(1);
   }
 
-  console.log(`synapse is running (PID: ${status.pid}, port: ${status.port})`);
+  const uptimeStr = status.uptime ? formatUptime(status.uptime) : "unknown";
+  console.log(
+    `synapse is running (PID: ${status.pid}, port: ${status.port}, uptime: ${uptimeStr})`,
+  );
   process.exit(0);
+}
+
+function formatUptime(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`;
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
+  const hours = Math.floor(seconds / 3600);
+  const mins = Math.floor((seconds % 3600) / 60);
+  return `${hours}h ${mins}m`;
 }
 
 async function cmdRestart(): Promise<void> {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -86,7 +86,8 @@ export async function getDaemonStatus(): Promise<DaemonStatus> {
   try {
     const response = await fetch(`http://localhost:${port}/health`);
     if (response.ok) {
-      return { running: true, pid, port };
+      const data = (await response.json()) as { uptime?: number };
+      return { running: true, pid, port, uptime: data.uptime };
     }
   } catch {
     // Server might be starting up

--- a/src/server.ts
+++ b/src/server.ts
@@ -215,6 +215,7 @@ async function handleHealth(
     {
       status: allHealthy ? "healthy" : "degraded",
       version: VERSION,
+      uptime: Math.floor((Date.now() - startTime) / 1000),
       providers: providerHealth,
     },
     {
@@ -225,6 +226,8 @@ async function handleHealth(
 }
 
 // --- Server ---
+
+const startTime = Date.now();
 
 export function createServer(config: SynapseConfig): {
   start: () => ReturnType<typeof Bun.serve>;


### PR DESCRIPTION
## Summary
- Add `uptime` field to `/health` endpoint response (seconds since server start)
- Parse uptime in `getDaemonStatus()` from the health response
- Display uptime in `synapse status` output, matching engram's format: `synapse is running (PID: X, port: Y, uptime: 3m 22s)`
- Add `formatUptime()` helper (same as engram's: `Xs`, `Xm Ys`, `Xh Ym`)