### PR TITLE
fix: version display and update core to v0.1.16

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -51,7 +51,7 @@
 
     "@oxlint/win32-x64": ["@oxlint/win32-x64@0.12.0", "", { "os": "win32", "cpu": "x64" }, "sha512-NHLJolo4sZk3nu/bPNuaJ+6p5DdHoRuZAjyuSO6CnLgpmZcYqx7LgngA/x2oB/bLgi4Hv9twjHjODc5Ce5o14g=="],
 
-    "@shetty4l/core": ["@shetty4l/core@0.1.14", "", { "bin": { "version-bump": "bin/version-bump.js" } }, "sha512-1JXHOwPSJkK3t7yUBzfiJ1V9uHUFVdJnN4zcNzg8IPYW6mgQtfVK46KYhflNvpONz6POgfhqaXc1n93sp0EKwA=="],
+    "@shetty4l/core": ["@shetty4l/core@0.1.16", "", { "bin": { "version-bump": "bin/version-bump.js" } }, "sha512-tiHDhTwYEXxliB89amQd+sJTtzyLmgIwJrT73IhR92gTRWTPkTO6OL1vVedpB+eL+2cd6+Zs5a2a2e/vE+UkYQ=="],
 
     "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,3 +1,4 @@
 import { readVersion } from "@shetty4l/core/version";
+import { join } from "path";
 
-export const VERSION = readVersion(import.meta.dir);
+export const VERSION = readVersion(join(import.meta.dir, ".."));


### PR DESCRIPTION
## Summary

- Fix `readVersion` rootDir to look at project root instead of `src/` — was always showing `0.0.0-dev`
- Update `@shetty4l/core` to v0.1.16 which fixes `runCli` killing long-running serve commands via premature `process.exit()`

Both issues caused deployment failures on the Mac Mini.