### PR TITLE
ci: add explicit CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,18 @@
+name: CodeQL
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+      - uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/codeql.yml` with explicit CodeQL analysis for `javascript-typescript`
- Default setup was disabled via API (conflicts with explicit workflow files)
- Ensures code scanning checks trigger reliably on PRs so ruleset requirements don't block merges

Matches the setup already applied to `shetty4l/diagrams`.