### PR TITLE
refactor: adopt Result type and replace hand-rolled config utilities with @shetty4l/core

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -9,9 +9,9 @@
  * String values in the config file support ${ENV_VAR} interpolation.
  */
 
-import { existsSync, readFileSync } from "fs";
-import { homedir } from "os";
-import { join } from "path";
+import { loadJsonConfig, parsePort } from "@shetty4l/core/config";
+import type { Result } from "@shetty4l/core/result";
+import { err, ok } from "@shetty4l/core/result";
 
 // --- Types ---
 
@@ -39,7 +39,7 @@ export interface SynapseConfig {
 
 const DEFAULT_PORT = 7750;
 
-const DEFAULT_CONFIG: SynapseConfig = {
+const DEFAULTS = {
   port: DEFAULT_PORT,
   providers: [
     {
@@ -52,100 +52,35 @@ const DEFAULT_CONFIG: SynapseConfig = {
   ],
 };
 
-const DEFAULT_CONFIG_PATH = join(
-  homedir(),
-  ".config",
-  "synapse",
-  "config.json",
-);
-
-// --- Port validation ---
-
-function parsePort(value: string, source: string): number {
-  const port = Number.parseInt(value, 10);
-  if (Number.isNaN(port) || port < 1 || port > 65535) {
-    throw new Error(
-      `${source}: "${value}" is not a valid port number (must be 1-65535)`,
-    );
-  }
-  return port;
-}
-
-// --- Env var interpolation ---
-
-/**
- * Replace ${ENV_VAR} patterns in a string with the corresponding env value.
- * Throws if the env var is not set.
- */
-export function interpolateEnvVars(value: string): string {
-  return value.replace(/\$\{([^}]+)\}/g, (_match, varName: string) => {
-    const envValue = process.env[varName];
-    if (envValue === undefined) {
-      throw new Error(
-        `Config references \${${varName}} but it is not set in the environment`,
-      );
-    }
-    return envValue;
-  });
-}
-
-/**
- * Recursively walk a JSON-parsed value and interpolate env vars in all strings.
- * Only accepts JSON-compatible types (no class instances).
- */
-type JsonValue =
-  | string
-  | number
-  | boolean
-  | null
-  | JsonValue[]
-  | { [key: string]: JsonValue };
-
-function interpolateDeep(value: JsonValue): JsonValue {
-  if (typeof value === "string") {
-    return interpolateEnvVars(value);
-  }
-  if (Array.isArray(value)) {
-    return value.map(interpolateDeep);
-  }
-  if (value !== null && typeof value === "object") {
-    const result: Record<string, JsonValue> = {};
-    for (const [k, v] of Object.entries(value)) {
-      result[k] = interpolateDeep(v);
-    }
-    return result;
-  }
-  return value;
-}
-
 // --- Validation ---
 
-function validateProvider(p: unknown, index: number): ProviderConfig {
+function validateProvider(
+  p: unknown,
+  index: number,
+): Result<ProviderConfig, string> {
   if (typeof p !== "object" || p === null) {
-    throw new Error(`providers[${index}]: must be an object`);
+    return err(`providers[${index}]: must be an object`);
   }
   const obj = p as Record<string, unknown>;
 
   if (typeof obj.name !== "string" || obj.name.length === 0) {
-    throw new Error(`providers[${index}].name: must be a non-empty string`);
+    return err(`providers[${index}].name: must be a non-empty string`);
   }
   if (typeof obj.baseUrl !== "string" || obj.baseUrl.length === 0) {
-    throw new Error(`providers[${index}].baseUrl: must be a non-empty string`);
+    return err(`providers[${index}].baseUrl: must be a non-empty string`);
   }
   if (!Array.isArray(obj.models) || obj.models.length === 0) {
-    throw new Error(
+    return err(
       `providers[${index}].models: must be a non-empty array of strings`,
     );
   }
   for (const m of obj.models) {
     if (typeof m !== "string") {
-      throw new Error(
-        `providers[${index}].models: all entries must be strings`,
-      );
+      return err(`providers[${index}].models: all entries must be strings`);
     }
   }
 
-  return {
+  return ok({
     name: obj.name,
     baseUrl: obj.baseUrl,
     apiKey: typeof obj.apiKey === "string" ? obj.apiKey : undefined,
@@ -153,45 +88,53 @@ function validateProvider(p: unknown, index: number): ProviderConfig {
     maxFailures: typeof obj.maxFailures === "number" ? obj.maxFailures : 3,
     cooldownSeconds:
       typeof obj.cooldownSeconds === "number" ? obj.cooldownSeconds : 60,
-  };
+  });
 }
 
-function validateConfig(raw: unknown): SynapseConfig {
+function validateConfig(raw: unknown): Result<SynapseConfig, string> {
   if (typeof raw !== "object" || raw === null) {
-    throw new Error("Config must be a JSON object");
+    return err("Config must be a JSON object");
   }
   const obj = raw as Record<string, unknown>;
 
-  const port =
-    typeof obj.port === "number"
-      ? (() => {
-          if (!Number.isInteger(obj.port) || obj.port < 1 || obj.port > 65535) {
-            throw new Error(
-              `port: ${obj.port} is not a valid port number (must be an integer 1-65535)`,
-            );
-          }
-          return obj.port;
-        })()
-      : DEFAULT_PORT;
-
-  if (!Array.isArray(obj.providers) || obj.providers.length === 0) {
-    throw new Error("Config must have a non-empty 'providers' array");
+  let port = DEFAULT_PORT;
+  if (obj.port !== undefined) {
+    if (
+      typeof obj.port !== "number" ||
+      !Number.isInteger(obj.port) ||
+      obj.port < 1 ||
+      obj.port > 65535
+    ) {
+      return err(
+        `port: ${obj.port} is not a valid port number (must be an integer 1-65535)`,
+      );
+    }
+    port = obj.port;
   }
 
-  const providers = obj.providers.map((p, i) => validateProvider(p, i));
+  if (!Array.isArray(obj.providers) || obj.providers.length === 0) {
+    return err("Config must have a non-empty 'providers' array");
+  }
+
+  const providers: ProviderConfig[] = [];
+  for (let i = 0; i < obj.providers.length; i++) {
+    const result = validateProvider(obj.providers[i], i);
+    if (!result.ok) return result as Result<never>;
+    providers.push(result.value);
+  }
 
   // Enforce unique provider names
   const names = new Set<string>();
   for (const p of providers) {
     if (names.has(p.name)) {
-      throw new Error(
+      return err(
         `Duplicate provider name "${p.name}". Each provider must have a unique name.`,
       );
     }
     names.add(p.name);
   }
 
-  return { port, providers };
+  return ok({ port, providers });
 }
 
 // --- Load ---
@@ -199,47 +142,45 @@ function validateConfig(raw: unknown): SynapseConfig {
 export function loadConfig(options?: {
   configPath?: string;
   quiet?: boolean;
-}): SynapseConfig {
-  const envPort = process.env.SYNAPSE_PORT;
-  const filePath =
-    options?.configPath ??
-    process.env.SYNAPSE_CONFIG_PATH ??
-    DEFAULT_CONFIG_PATH;
+}): Result<SynapseConfig, string> {
+  const configPath =
+    options?.configPath ?? process.env.SYNAPSE_CONFIG_PATH ?? undefined;
   const quiet = options?.quiet ?? false;
 
-  if (!existsSync(filePath)) {
-    if (!quiet) {
-      console.error(
-        `synapse: no config at ${filePath}, using defaults (ollama @ localhost:11434)`,
-      );
-    }
-    const config = { ...DEFAULT_CONFIG };
-    if (envPort) {
-      config.port = parsePort(envPort, "SYNAPSE_PORT");
-    }
-    return config;
-  }
+  // Load file config via core (handles file reading, JSON parsing, env interpolation)
+  const loaded = loadJsonConfig({
+    name: "synapse",
+    defaults: DEFAULTS as Record<string, unknown>,
+    configPath,
+  });
 
-  const rawText = readFileSync(filePath, "utf-8");
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(rawText);
-  } catch {
-    throw new Error(`Failed to parse config file ${filePath}: invalid JSON`);
-  }
+  if (!loaded.ok) return loaded;
 
-  const interpolated = interpolateDeep(parsed as JsonValue);
-  const config = validateConfig(interpolated);
-
-  // Env var overrides
-  if (envPort) {
-    config.port = parsePort(envPort, "SYNAPSE_PORT");
-  }
+  // When no config file exists, loadJsonConfig returns defaults merged.
+  // But our defaults include a providers array, so validateConfig will work.
+  const validated = validateConfig(loaded.value.config);
+  if (!validated.ok) return validated;
 
   if (!quiet) {
-    console.error(
-      `synapse: loaded config from ${filePath} (${config.providers.length} provider(s))`,
-    );
+    if (loaded.value.source === "file") {
+      console.error(
+        `synapse: loaded config from ${loaded.value.path} (${validated.value.providers.length} provider(s))`,
+      );
+    } else {
+      console.error(
+        `synapse: no config at ${loaded.value.path}, using defaults (ollama @ localhost:11434)`,
+      );
+    }
   }
-  return config;
+
+  const config = validated.value;
+
+  // Env var overrides
+  if (process.env.SYNAPSE_PORT) {
+    const portResult = parsePort(process.env.SYNAPSE_PORT, "SYNAPSE_PORT");
+    if (!portResult.ok) return portResult as Result<never>;
+    config.port = portResult.value;
+  }
+
+  return ok(config);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,10 @@ import { VERSION } from "./version";
 
 console.error(`synapse v${VERSION}`);
 
-const config = loadConfig();
-const server = createServer(config);
+const configResult = loadConfig();
+if (!configResult.ok) {
+  console.error(`synapse: config error: ${configResult.error}`);
+  process.exit(1);
+}
+const server = createServer(configResult.value);
 server.start();

--- a/src/server.ts
+++ b/src/server.ts
@@ -44,9 +44,10 @@ async function getCachedReachability(provider: {
     return entry.reachable;
   }
 
-  const reachable = await checkReachable(
+  const result = await checkReachable(
     provider as import("./config").ProviderConfig,
   );
+  const reachable = result.ok;
   reachabilityCache.set(cacheKey, { reachable, cachedAt: Date.now() });
   return reachable;
 }


### PR DESCRIPTION
## Summary
- **Delete ~60 lines of duplicated code:** Hand-rolled `parsePort()`, `interpolateEnvVars()`, `interpolateDeep()` replaced with `@shetty4l/core/config` imports that return `Result`
- **Rewrite `loadConfig()`** on top of `loadJsonConfig()` from core (like cortex does)
- **All validation → Result:** `validateProvider()` (5 throw sites), `validateConfig()` (4 throw sites) now return `Result` instead of throwing
- **Provider calls → Result:** `chatCompletions()` returns `Result<ProviderResult>`, router replaces try/catch with `if (!result.ok)` pattern
- **Daemon → Result:** `startDaemon()`/`stopDaemon()` return `Result` with descriptive errors. Console output moved to CLI callers (separation of concerns).
- **Zero `throw` statements remain** in source files for expected failures

## Changes
| File | Change |
|------|--------|
| `src/config.ts` | Deleted 3 duplicates, rewritten on `loadJsonConfig()`, all validation → Result |
| `src/provider.ts` | `chatCompletions()`/`listModels()`/`checkReachable()` → `Result`. Extracted `Model` interface. |
| `src/router.ts` | try/catch → `if (!result.ok)`. Cleaner chain walk. |
| `src/daemon.ts` | `startDaemon()`/`stopDaemon()`/`restartDaemon()` → `Result`. Console output to callers. |
| `src/cli.ts` | All callers handle `Result` with descriptive error messages |
| `src/server.ts` | `getCachedReachability()` uses `result.ok` |
| `src/index.ts` | Handles `Result` from `loadConfig()` |
| `test/config.test.ts` | Adapted for Result semantics, imports from core |

## Testing
- `bun run validate` passes clean (typecheck + oxlint + biome + 35 tests, 90 assertions)
- HTTP API behavior unchanged — same OpenAI-compatible responses (verified by 9 HTTP integration tests)
- Net +2 lines (~267 added, ~265 removed) — config deduplication offsets new Result handling