### PR TITLE
refactor: adopt core path utilities and extract run() function

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,8 +20,8 @@
  */
 
 import { createLogsCommand, formatUptime, runCli } from "@shetty4l/core/cli";
+import { getConfigDir } from "@shetty4l/core/config";
 import { onShutdown } from "@shetty4l/core/signals";
-import { homedir } from "os";
 import { join } from "path";
 import { loadConfig } from "./config";
 import {
@@ -52,11 +52,11 @@ Options:
   --help, -h             Show help
 `;
 
-const LOG_PATH = join(homedir(), ".config", "synapse", "logs", "requests.log");
+const LOG_PATH = join(getConfigDir("synapse"), "synapse.log");
 
 // --- Commands ---
 
-function cmdServe(): void {
+export function run(): void {
   const configResult = loadConfig();
   if (!configResult.ok) {
     console.error(`synapse: config error: ${configResult.error}`);
@@ -70,8 +70,12 @@ function cmdServe(): void {
       await server.logger.shutdown();
       instance.stop();
     },
-    { name: "synapse" },
+    { name: "synapse", timeoutMs: 15_000 },
   );
+}
+
+function cmdServe(): void {
+  run();
 }
 
 async function cmdStart(): Promise<number> {
@@ -214,7 +218,7 @@ function cmdConfig(_args: string[], json: boolean): void {
 
 const cmdLogs = createLogsCommand({
   logFile: LOG_PATH,
-  emptyMessage: "No request logs found.",
+  emptyMessage: "No daemon logs found.",
   defaultCount: 10,
 });
 

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -5,16 +5,16 @@
  * Preserves the existing function signatures so cli.ts call sites are unchanged.
  */
 
+import { getConfigDir } from "@shetty4l/core/config";
 import { createDaemonManager, type DaemonStatus } from "@shetty4l/core/daemon";
 import type { Result } from "@shetty4l/core/result";
 import { err, ok } from "@shetty4l/core/result";
-import { homedir } from "os";
 import { join } from "path";
 import { loadConfig } from "./config";
 
 export type { DaemonStatus };
 
-const CONFIG_DIR = join(homedir(), ".config", "synapse");
+const CONFIG_DIR = getConfigDir("synapse");
 
 function getHealthUrl(): string {
   const configResult = loadConfig({ quiet: true });

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,19 +4,8 @@
  * Entry point. Loads config and starts the HTTP server.
  */
 
-import { createLogger } from "@shetty4l/core/log";
-import { loadConfig } from "./config";
-import { createServer } from "./server";
-import { VERSION } from "./version";
+import { run } from "./cli";
 
-const log = createLogger("synapse");
-
-log(`v${VERSION}`);
-
-const configResult = loadConfig();
-if (!configResult.ok) {
-  log(`config error: ${configResult.error}`);
-  process.exit(1);
+if (import.meta.main) {
+  run();
 }
-const server = createServer(configResult.value);
-server.start();

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -10,10 +10,10 @@
  * Uses async I/O and batched writes to avoid blocking the event loop.
  */
 
+import { getConfigDir } from "@shetty4l/core/config";
 import { createLogger } from "@shetty4l/core/log";
 import { existsSync, mkdirSync } from "fs";
 import { appendFile, rename, stat, unlink } from "fs/promises";
-import { homedir } from "os";
 import { join } from "path";
 
 const log = createLogger("synapse");
@@ -32,7 +32,7 @@ export interface RequestLogEntry {
 
 const MAX_SIZE_BYTES = 50 * 1024 * 1024; // 50 MB
 const FLUSH_INTERVAL_MS = 1_000; // Flush buffer every second
-const DEFAULT_LOG_DIR = join(homedir(), ".config", "synapse", "logs");
+const DEFAULT_LOG_DIR = join(getConfigDir("synapse"), "logs");
 
 export class RequestLogger {
   private readonly logPath: string;


### PR DESCRIPTION
## Summary

Brings synapse in line with how cortex uses `@shetty4l/core` utilities.

### Path utilities (`getConfigDir`)
- **`src/daemon.ts`**: Replace `join(homedir(), ".config", "synapse")` with `getConfigDir("synapse")`, remove `homedir` import
- **`src/logger.ts`**: Replace hardcoded `DEFAULT_LOG_DIR` with `join(getConfigDir("synapse"), "logs")`, remove `homedir` import
- **`src/cli.ts`**: Replace hardcoded `LOG_PATH` with `join(getConfigDir("synapse"), "synapse.log")`, remove `homedir` import

### Logs path bugfix
- `synapse logs` was pointing at `logs/requests.log` (JSONL request log) instead of `synapse.log` (daemon stderr). This made `synapse logs` show different output than `cortex logs`/`engram logs`. Fixed to use `synapse.log` for consistency.

### Extract `run()` function
- Extracted startup logic from `cmdServe()` into an exported `run()` function
- `cmdServe()` now just calls `run()`
- `src/index.ts` (`import.meta.main` block) now calls `run()` instead of duplicating startup logic

### Shutdown timeout
- Added `timeoutMs: 15_000` to `onShutdown()` call so synapse doesn't hang indefinitely on shutdown

### Files changed
- `src/cli.ts` — path fix, logs bugfix, extract `run()`, shutdown timeout
- `src/daemon.ts` — path fix
- `src/logger.ts` — path fix
- `src/index.ts` — delegate to `run()` from cli.ts