### PR TITLE
refactor: adopt core HTTP utilities in server

### DIFF
--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -197,13 +197,11 @@ describe("HTTP integration", () => {
     expect(res.headers.get("access-control-allow-methods")).toContain("POST");
   });
 
-  test("GET /unknown — 404 in OpenAI error format", async () => {
+  test("GET /unknown — 404", async () => {
     const res = await fetch(`${base}/unknown-path`);
     expect(res.status).toBe(404);
 
-    const data = (await res.json()) as {
-      error: { type: string; message: string };
-    };
-    expect(data.error.type).toBe("not_found");
+    const data = (await res.json()) as { error: string };
+    expect(data.error).toContain("Unknown endpoint");
   });
 });


### PR DESCRIPTION
## Summary

- Import `corsHeaders`, `corsPreflightResponse`, `healthResponse`, `jsonOk`, `jsonError` from `@shetty4l/core/http` instead of defining them locally
- Delete synapse's own `corsHeaders()` and `handleCors()` functions (replaced by core imports)
- Use `corsPreflightResponse()` for OPTIONS handling, `jsonOk()` for models endpoint, `healthResponse()` with `extra` param for healthy state, `jsonError()` for 404 on unknown endpoints
- Keep `openaiError()` for OpenAI-compatible error responses on API endpoints (400, 405, 413, 502) — this is application-specific formatting that core should not own
- Keep `Bun.serve` directly (not core's `createServer`) because synapse needs custom `/health` with provider status data that core's built-in health handler doesn't support

## What was kept custom and why

| Concern | Source | Reason |
|---|---|---|
| `openaiError()` | synapse | OpenAI-compat `{ error: { message, type } }` format is app-specific |
| `Bun.serve` (not `createServer`) | synapse | Core's `createServer` intercepts `/health` before `onRequest`, preventing custom provider health data |
| Request logging | synapse | Per-request access log with latency is synapse-specific |
| `RequestLogger` | synapse | JSONL request logging with rotation is synapse-specific |

## Files changed

- `src/server.ts` — replaced local CORS/response utilities with core imports, net -11 lines
- `test/http.test.ts` — updated 404 test to match `jsonError` format (plain error string vs OpenAI object)