### PR TITLE
refactor: adopt core createServer with onHealth hook

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "synapse",
       "dependencies": {
-        "@shetty4l/core": ">=0.1.0 <1.0.0",
+        "@shetty4l/core": "^0.1.29",
       },
       "devDependencies": {
         "@biomejs/biome": "^2.3.13",
@@ -73,7 +73,7 @@
 
     "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.49.0", "", { "os": "win32", "cpu": "x64" }, "sha512-VteIelt78kwzSglOozaQcs6BCS4Lk0j+QA+hGV0W8UeyaqQ3XpbZRhDU55NW1PPvCy1tg4VXsTlEaPovqto7nQ=="],
 
-    "@shetty4l/core": ["@shetty4l/core@0.1.28", "", { "bin": { "version-bump": "bin/version-bump.js" } }, "sha512-Xe3QMu3mKoZmIziyNzQsP7CkkxNdYGz9dUwXwC7hkXFtAwhGOwi2KLr0svRLJgP6phUkZcXK01C+i65CcQyj/w=="],
+    "@shetty4l/core": ["@shetty4l/core@0.1.29", "", { "bin": { "version-bump": "bin/version-bump.js" } }, "sha512-AinkW6Lx5zX8+CeYlCOddNonG+NqvB3MAw1DY42ymUWiQwumsd4Pm8xBIj/P4gQ6MTvjdk79WC7+NDGevrMwpA=="],
 
     "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@shetty4l/core": ">=0.1.0 <1.0.0"
+    "@shetty4l/core": "^0.1.29"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.3.13",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -63,12 +63,11 @@ export function run(): void {
     process.exit(1);
   }
   const server = createServer(configResult.value);
-  const instance = server.start();
 
   onShutdown(
     async () => {
       await server.logger.shutdown();
-      instance.stop();
+      server.stop();
     },
     { name: "synapse", timeoutMs: 15_000 },
   );

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import type { SynapseServer } from "../src/server";
 import { createServer } from "../src/server";
 
 type BunServer = ReturnType<typeof Bun.serve>;
@@ -69,11 +70,11 @@ function startMockUpstream(): BunServer {
 
 describe("HTTP integration", () => {
   let mockUpstream: BunServer;
-  let synapseServer: BunServer;
+  let synapseServer: SynapseServer;
 
   beforeAll(() => {
     mockUpstream = startMockUpstream();
-    const server = createServer({
+    synapseServer = createServer({
       port: SYNAPSE_PORT,
       providers: [
         {
@@ -85,11 +86,10 @@ describe("HTTP integration", () => {
         },
       ],
     });
-    synapseServer = server.start();
   });
 
   afterAll(() => {
-    synapseServer.stop(true);
+    synapseServer.stop();
     mockUpstream.stop(true);
   });
 
@@ -202,6 +202,6 @@ describe("HTTP integration", () => {
     expect(res.status).toBe(404);
 
     const data = (await res.json()) as { error: string };
-    expect(data.error).toContain("Unknown endpoint");
+    expect(data.error).toContain("Not found");
   });
 });


### PR DESCRIPTION
## Summary
- Replaces raw `Bun.serve` in `server.ts` with core's `createServer`, using the new `onHealth` callback for custom provider health status (503 for degraded)
- Removes duplicated CORS preflight and 404 handling — now delegated to core
- Simplifies `createServer` return shape from `{ start(), logger }` to `{ port, stop(), logger }` (server starts immediately)
- Bumps `@shetty4l/core` to pick up the `onHealth` hook (core#44)

## Changes
- **`src/server.ts`**: Import core's `createServer` (aliased), wire `onHealth` and `onRequest`, remove manual OPTIONS/404/startTime handling, export `SynapseServer` interface
- **`src/cli.ts`**: Remove `.start()` call, use `server.stop()` directly
- **`test/http.test.ts`**: Adapt to new return shape, update 404 assertion ("Not found" from core instead of "Unknown endpoint")
- **`bun.lock` / `package.json`**: Core dep updated

## Net effect
- 54 insertions, 60 deletions (net -6 lines)
- All 35 tests pass, typecheck/lint/format clean