### PR TITLE
chore: suppress /stats endpoint from HTTP logs

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -299,8 +299,10 @@ export function createServer(config: SynapseConfig): SynapseServer {
         return null;
       }
 
-      const latency = (performance.now() - start).toFixed(0);
-      log(`${req.method} ${path} ${response.status} ${latency}ms`);
+      if (path !== "/stats") {
+        const latency = (performance.now() - start).toFixed(0);
+        log(`${req.method} ${path} ${response.status} ${latency}ms`);
+      }
 
       return response;
     },


### PR DESCRIPTION
## Summary

- Skip logging for `/stats` endpoint requests to reduce log noise
- Dashboard polls `/stats` frequently, creating excessive log entries

## Related PRs

- shetty4l/cortex - same change
- shetty4l/engram - same change