### PR TITLE
feat(synapse): structured output support for Ollama providers

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -31,6 +31,8 @@ export interface ProviderConfig {
   maxFailures?: number;
   /** Seconds to wait before retrying an unhealthy provider (default: 60) */
   cooldownSeconds?: number;
+  /** Provider type for request translation (default: "openai") */
+  type?: "openai" | "ollama";
 }
 
 export interface SynapseConfig {
@@ -83,6 +85,12 @@ function validateProvider(
     }
   }
 
+  // Validate type field: must be "openai" or "ollama", default to "openai"
+  let type: "openai" | "ollama" = "openai";
+  if (obj.type === "openai" || obj.type === "ollama") {
+    type = obj.type;
+  }
+
   return ok({
     name: obj.name,
     baseUrl: obj.baseUrl,
@@ -91,6 +99,7 @@ function validateProvider(
     maxFailures: typeof obj.maxFailures === "number" ? obj.maxFailures : 3,
     cooldownSeconds:
       typeof obj.cooldownSeconds === "number" ? obj.cooldownSeconds : 60,
+    type,
   });
 }
 

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -40,6 +40,55 @@ const TIMEOUT_MS = 120_000; // 2 minutes
 const STREAM_IDLE_TIMEOUT_MS = 30_000; // 30 seconds between chunks
 
 /**
+ * Translate request body for provider-specific format requirements.
+ *
+ * OpenAI uses: response_format: { type: "json_schema", json_schema: { schema: {...} } }
+ * Ollama uses: format: {...schema...}
+ *
+ * For OpenAI-type providers, pass through unchanged.
+ * For Ollama-type providers, extract json_schema.schema and move to format field.
+ */
+export function translateRequestBody(
+  body: string,
+  providerType: "openai" | "ollama",
+): string {
+  // OpenAI-compatible providers: pass through unchanged
+  if (providerType === "openai") {
+    return body;
+  }
+
+  // Ollama: translate response_format.json_schema.schema → format
+  try {
+    const parsed = JSON.parse(body) as Record<string, unknown>;
+
+    // Only translate if response_format exists and has the expected structure
+    const responseFormat = parsed.response_format as
+      | Record<string, unknown>
+      | undefined;
+    if (!responseFormat) {
+      return body;
+    }
+
+    const jsonSchema = responseFormat.json_schema as
+      | Record<string, unknown>
+      | undefined;
+    if (!jsonSchema?.schema) {
+      return body;
+    }
+
+    // Extract the schema and set as format, remove response_format
+    const translated = { ...parsed };
+    translated.format = jsonSchema.schema;
+    delete translated.response_format;
+
+    return JSON.stringify(translated);
+  } catch {
+    // If JSON parsing fails, return original body (let downstream error)
+    return body;
+  }
+}
+
+/**
  * Wrap a ReadableStream with an idle timeout that aborts if no data
  * arrives within the given interval. Also ensures cleanup on completion.
  */
@@ -99,6 +148,9 @@ export async function chatCompletions(
     headers["Authorization"] = `Bearer ${provider.apiKey}`;
   }
 
+  // Translate request body for provider-specific format
+  const translatedBody = translateRequestBody(body, provider.type ?? "openai");
+
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
 
@@ -111,7 +163,7 @@ export async function chatCompletions(
     const response = await fetch(url, {
       method: "POST",
       headers,
-      body,
+      body: translatedBody,
       signal: controller.signal,
     });
 

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -163,4 +163,91 @@ describe("loadConfig", () => {
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.error).toContain("non-empty string");
   });
+
+  test("accepts type: 'ollama' for provider", () => {
+    const configPath = join(tmpDir, "config.json");
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        providers: [
+          {
+            name: "local-ollama",
+            baseUrl: "http://localhost:11434/v1",
+            models: ["*"],
+            type: "ollama",
+          },
+        ],
+      }),
+    );
+
+    const result = loadConfig({ configPath, quiet: true });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.providers[0].type).toBe("ollama");
+  });
+
+  test("accepts type: 'openai' for provider", () => {
+    const configPath = join(tmpDir, "config.json");
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        providers: [
+          {
+            name: "openai",
+            baseUrl: "https://api.openai.com/v1",
+            models: ["gpt-4"],
+            type: "openai",
+          },
+        ],
+      }),
+    );
+
+    const result = loadConfig({ configPath, quiet: true });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.providers[0].type).toBe("openai");
+  });
+
+  test("defaults type to 'openai' when not specified", () => {
+    const configPath = join(tmpDir, "config.json");
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        providers: [
+          {
+            name: "no-type",
+            baseUrl: "http://localhost:8080/v1",
+            models: ["*"],
+          },
+        ],
+      }),
+    );
+
+    const result = loadConfig({ configPath, quiet: true });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.providers[0].type).toBe("openai");
+  });
+
+  test("defaults invalid type to 'openai'", () => {
+    const configPath = join(tmpDir, "config.json");
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        providers: [
+          {
+            name: "invalid-type",
+            baseUrl: "http://localhost:8080/v1",
+            models: ["*"],
+            type: "invalid",
+          },
+        ],
+      }),
+    );
+
+    const result = loadConfig({ configPath, quiet: true });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.providers[0].type).toBe("openai");
+  });
 });

--- a/test/provider.test.ts
+++ b/test/provider.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "bun:test";
+import { translateRequestBody } from "../src/provider";
+
+describe("translateRequestBody", () => {
+  test("OpenAI: passes response_format unchanged", () => {
+    const body = JSON.stringify({
+      model: "gpt-4",
+      messages: [{ role: "user", content: "Hello" }],
+      response_format: {
+        type: "json_schema",
+        json_schema: {
+          name: "response",
+          schema: {
+            type: "object",
+            properties: {
+              answer: { type: "string" },
+            },
+            required: ["answer"],
+          },
+        },
+      },
+    });
+
+    const result = translateRequestBody(body, "openai");
+    expect(result).toBe(body);
+  });
+
+  test("Ollama: translates response_format.json_schema.schema to format", () => {
+    const body = JSON.stringify({
+      model: "llama3",
+      messages: [{ role: "user", content: "Hello" }],
+      response_format: {
+        type: "json_schema",
+        json_schema: {
+          name: "response",
+          schema: {
+            type: "object",
+            properties: {
+              answer: { type: "string" },
+            },
+            required: ["answer"],
+          },
+        },
+      },
+    });
+
+    const result = translateRequestBody(body, "ollama");
+    const parsed = JSON.parse(result) as Record<string, unknown>;
+
+    // response_format should be removed
+    expect(parsed.response_format).toBeUndefined();
+
+    // format should contain the schema
+    expect(parsed.format).toEqual({
+      type: "object",
+      properties: {
+        answer: { type: "string" },
+      },
+      required: ["answer"],
+    });
+
+    // Other fields preserved
+    expect(parsed.model).toBe("llama3");
+    expect(parsed.messages).toEqual([{ role: "user", content: "Hello" }]);
+  });
+
+  test("Ollama: without response_format passes through unchanged", () => {
+    const body = JSON.stringify({
+      model: "llama3",
+      messages: [{ role: "user", content: "Hello" }],
+    });
+
+    const result = translateRequestBody(body, "ollama");
+    expect(result).toBe(body);
+  });
+
+  test("request with format field (not response_format) passes through for both", () => {
+    const body = JSON.stringify({
+      model: "llama3",
+      messages: [{ role: "user", content: "Hello" }],
+      format: {
+        type: "object",
+        properties: {
+          answer: { type: "string" },
+        },
+      },
+    });
+
+    // OpenAI passes through
+    const openaiResult = translateRequestBody(body, "openai");
+    expect(openaiResult).toBe(body);
+
+    // Ollama also passes through (no response_format to translate)
+    const ollamaResult = translateRequestBody(body, "ollama");
+    expect(ollamaResult).toBe(body);
+  });
+
+  test("invalid JSON body gracefully returns original", () => {
+    const invalidBody = "{ invalid json }";
+
+    // OpenAI passes through (no parsing attempted)
+    const openaiResult = translateRequestBody(invalidBody, "openai");
+    expect(openaiResult).toBe(invalidBody);
+
+    // Ollama also returns original (catch block)
+    const ollamaResult = translateRequestBody(invalidBody, "ollama");
+    expect(ollamaResult).toBe(invalidBody);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `type` field to ProviderConfig for distinguishing OpenAI vs Ollama providers
- Implement `translateRequestBody()` to convert `response_format.json_schema.schema` to Ollama's `format` field
- Add comprehensive test coverage for structured output translation

## Commits
1. `feat(synapse): add provider type for structured output translation`
2. `test(synapse): add structured output translation tests`

## Validation
All checks pass (typecheck, lint, format, 63 tests).

---
Closes #27